### PR TITLE
add link to the package github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ separating the content from the output by treating entries as data.
 
 ## Installation
 
-The development version from [GitHub](https://github.com/) with:
+The development version from [GitHub](https://github.com/nstrayer/datadrivencv) with:
 
 ``` r
 # install.packages("devtools")


### PR DESCRIPTION
just a small thing, i couldn't find a direct link to the GH repo on the package webpage. 