### PR TITLE
Switched icon dependency from CRAN to github remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,10 +22,12 @@ Imports:
     usethis,
     pagedown,
     fs,
-    icon
+    icon (>= 0.1.0)
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 Suggests: 
     knitr,
     rmarkdown
 VignetteBuilder: knitr
+Remotes:  
+    ropenscilabs/icon


### PR DESCRIPTION
When I added the missing dependency on the `icon` package I accidentally used a CRAN dependency instead of a github remote. Thanks to @spkaluzny to pointing this out in https://github.com/nstrayer/datadrivencv/issues/9#issuecomment-633262733.