### PR TITLE
Allow no description

### DIFF
--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -78,7 +78,7 @@ create_CV_object <-  function(data_location,
       na.rm = TRUE
     ) %>%
     dplyr::mutate(
-      description_bullets = paste0("- ", description_bullets),
+      description_bullets = ifelse(description_bullets != "", paste0("- ", description_bullets), ""),
       start = ifelse(start == "NULL", NA, start),
       end = ifelse(end == "NULL", NA, end),
       start_year = extract_year(start),


### PR DESCRIPTION
This PR fixes empty description bullet problem (#19) by making an addition of leading bullet conditional on the description content existing