### PR TITLE
Allow square brackets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     fs,
     icon (>= 0.1.0),
     whisker
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)
 Suggests: 
     knitr,

--- a/R/use_datadriven_cv.R
+++ b/R/use_datadriven_cv.R
@@ -56,13 +56,13 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
                               pdf_location = "https://github.com/nstrayer/cv/raw/master/strayer_cv.pdf",
                               html_location = "nickstrayer.me/datadrivencv/",
                               source_location = "https://github.com/nstrayer/datadrivencv",
-                              which_files = "all",
+                              which_files,
                               output_dir = getwd(),
                               create_output_dir = FALSE,
                               use_network_logo = TRUE,
                               open_files = TRUE){
 
-  if(is.character(which_files) && which_files == "all"){
+  if(missing(which_files)){
     which_files <- c("cv.rmd", "dd_cv.css", "render_cv.r", "cv_printing_functions.r")
   }
   # Make case-insensitive
@@ -91,7 +91,7 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
     use_ddcv_template(
       file_name = "dd_cv.css",
       output_dir = output_dir,
-      create_output_dir
+      create_output_dir = create_output_dir
     )
   }
 
@@ -99,7 +99,10 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
     use_ddcv_template(
       file_name = "render_cv.r",
       output_dir = output_dir,
-      create_output_dir,
+      params = list(
+        data_location = data_location
+      ),
+      create_output_dir = create_output_dir,
       open_after_making = open_files
     )
   }
@@ -108,7 +111,7 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
     use_ddcv_template(
       file_name = "cv_printing_functions.r",
       output_dir = output_dir,
-      create_output_dir
+      create_output_dir = create_output_dir
     )
   }
 

--- a/R/use_datadriven_cv.R
+++ b/R/use_datadriven_cv.R
@@ -61,8 +61,7 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
                               create_output_dir = FALSE,
                               use_network_logo = TRUE,
                               open_files = TRUE){
-
-  if(missing(which_files)){
+  if(missing(which_files) || tolower(which_files) == "all"){
     which_files <- c("cv.rmd", "dd_cv.css", "render_cv.r", "cv_printing_functions.r")
   }
   # Make case-insensitive

--- a/R/use_ddcv_template.R
+++ b/R/use_ddcv_template.R
@@ -12,7 +12,7 @@
 use_ddcv_template <- function(
   file_name,
   params = NULL,
-  output_file_name = file_name,
+  output_file_name,
   output_dir = getwd(),
   create_output_dir = FALSE,
   warn_about_no_change = TRUE,
@@ -25,7 +25,9 @@ use_ddcv_template <- function(
   if(output_dir_missing & !create_output_dir) {
     stop(glue::glue("The requested output directory: {output_dir} doesn't exist. Either set create_output_dir = TRUE or manually make directory."))
   }
-
+  if(missing(output_file_name)){
+    output_file_name <- file_name
+  }
 
   template_loc <- fs::path(system.file("templates/", package = "datadrivencv"), file_name)
   output_loc <- fs::path(output_dir, output_file_name)

--- a/README.Rmd
+++ b/README.Rmd
@@ -184,6 +184,41 @@ embed_png("html_vs_pdf_output.png")
 
 This script will render your CV in HTML and output it as `cv.html`, it will also turn on the `pdf_mode` parameter in `cv.rmd`, which will strip the links out and place them at the end linked by inline superscripts. Once the pdf version is rendered to HTML, it will then turn that HTML into a PDF using `pagedown::chrome_print()`. By using this script you can easily make sure your get both versions rendered at the same time without having to manually go in and toggle the pdf mode parameter in the yaml header and then use the print dialog in your browser. 
 
+
+### Caching your data
+
+Google Sheets is great for keeping and editing data but it has two problems: 
+
+1. It can be a pain to authenticate for access (especially in non-interactive modes)
+2. It's slow if youre rapidly iterating on your CV. 
+
+
+To deal with this, the default state of rendering will be to cache your data from google sheets (or your CSVs). 
+
+Caching works like so: 
+
+- If `cache_data` is set to `TRUE` in the RMarkdown parameters (it defaults to `TRUE`)
+  - The function `create_CV_object()` that is stored in `cv_printing_functions.r` will look for a file `ddcv_cache.rds`.
+      - If it cant find this, it downloads your data normally and then saves it to the file `ddcv_cache.rds`
+      - If it _can_ find it, it uses the `.rds` file instead of downloading data from google sheets (or CSVs).
+- Otherwise, each time `create_CV_object()` is run (whenever your CV is knit) the data is fetched from its source. 
+
+The easiest way to use caching is to uncomment commented-out set of lines in `render_cv.r`:
+
+```{r, eval = FALSE}
+# source("CV_printing_functions.R")
+# create_CV_object(
+#   data_location = "<your data loc>",
+#   cache_data = TRUE
+# )
+```
+
+Non-public sheets benefit a lot from this approach as setting up authentication for non-interactive access (e.g. knitting an RMD) is a pain. This way you can handle all the authentication in an interactive runtime. 
+
+You can also just render normally and the first time the kniting runs it will cache automatically.
+
+If you need to refresh the data either set `cache_data <- FALSE` in the `render_cv.R` script or delete `ddcv_cache.rds` and rerun the `create_CV_object()` function. 
+
 # Questions?
 
 Confused by anything (there's a lot to be confused by)? [Open an issue on github](https://github.com/nstrayer/datadrivencv/issues/new) and let me know. Not comfortable with github issues? Tweet the question at me on Twitter: [\@nicholasstrayer](https://twitter.com/NicholasStrayer).

--- a/README.md
+++ b/README.md
@@ -206,6 +206,46 @@ can easily make sure your get both versions rendered at the same time
 without having to manually go in and toggle the pdf mode parameter in
 the yaml header and then use the print dialog in your browser.
 
+### Caching your data
+
+Google Sheets is great for keeping and editing data but it has two
+problems:
+
+1.  It can be a pain to authenticate for access (especially in
+    non-interactive modes)
+2.  It’s slow if youre rapidly iterating on your CV.
+
+To deal with this, the default state of rendering will be to cache your
+data from google sheets (or your CSVs).
+
+Caching works like so:
+
+  - If `cache_data` is set to `TRUE` in the RMarkdown parameters (it
+    defaults to `TRUE`)
+      - The function `create_CV_object()` that is stored in
+        `cv_printing_functions.r` will look for a file `ddcv_cache.rds`.
+          - If it cant find this, it downloads your data normally and
+            then saves it to the file `ddcv_cache.rds`
+          - If it *can* find it, it uses the `.rds` file instead of
+            downloading data from google sheets (or CSVs).
+  - Otherwise, each time `create_CV_object()` is run (whenever your CV
+    is knit) the data is fetched from its source.
+
+The easiest way to use caching is to uncomment commented-out set of
+lines in `render_cv.r`:
+
+Non-public sheets benefit a lot from this approach as setting up
+authentication for non-interactive access (e.g. knitting an RMD) is a
+pain. This way you can handle all the authentication in an interactive
+runtime.
+
+You can also just render normally and the first time the kniting runs it
+will cache automatically.
+
+If you need to refresh the data either set `cache_data <- FALSE` in the
+`render_cv.R` script or delete `ddcv_cache.rds` and rerun the
+`create_CV_object()` function.
+
 # Questions?
 
 Confused by anything (there’s a lot to be confused by)? [Open an issue

--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -129,7 +129,7 @@ load_data <- function(cv, data_location, sheet_is_publicly_readable){
     cat(glue::glue("CV data is cached at {cache_loc}.\n"))
   }
 
-  cv
+  invisible(cv)
 }
 
 

--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -155,7 +155,7 @@ sanitize_links <- function(cv, text){
       # Replace the link destination and remove square brackets for title
       text <- text %>%
         stringr::str_replace_all(stringr::fixed(link_superscript_mappings)) %>%
-        stringr::str_replace_all('\\[(.+?)\\]', "\\1")
+        stringr::str_replace_all('\\[(.+?)\\](?=<sup>)', "\\1")
     }
   }
 

--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -136,8 +136,8 @@ load_data <- function(cv, data_location, sheet_is_publicly_readable){
 # Remove links from a text block and add to internal list
 sanitize_links <- function(cv, text){
   if(cv$pdf_mode){
-    link_titles <- stringr::str_extract_all(text, '(?<=\\[).+?(?=\\])')[[1]]
-    link_destinations <- stringr::str_extract_all(text, '(?<=\\().+?(?=\\))')[[1]]
+    link_titles <- stringr::str_extract_all(text, '(?<=\\[).+?(?=\\]\\()')[[1]]
+    link_destinations <- stringr::str_extract_all(text, '(?<=\\]\\().+?(?=\\))')[[1]]
 
     n_links <- length(cv$links)
     n_new_links <- length(link_titles)

--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -108,9 +108,9 @@ load_data <- function(cv, data_location, sheet_is_publicly_readable){
     cv$contact_info  <- read_gsheet(sheet_id = "contact_info")
   } else {
     # Want to go old-school with csvs?
-    cv$entries_data <- readr::read_csv(paste0(data_location, "entries.csv"))
-    cv$skills       <- readr::read_csv(paste0(data_location, "language_skills.csv"))
-    cv$text_blocks  <- readr::read_csv(paste0(data_location, "text_blocks.csv"))
+    cv$entries_data <- readr::read_csv(paste0(data_location, "entries.csv"), skip = 1)
+    cv$skills       <- readr::read_csv(paste0(data_location, "language_skills.csv"), skip = 1)
+    cv$text_blocks  <- readr::read_csv(paste0(data_location, "text_blocks.csv"), skip = 1)
     cv$contact_info <- readr::read_csv(paste0(data_location, "contact_info.csv"), skip = 1)
   }
 

--- a/inst/templates/cv.Rmd
+++ b/inst/templates/cv.Rmd
@@ -5,6 +5,8 @@ date: "`r Sys.Date()`"
 params:
   pdf_mode:
     value: true
+  cache_data:
+    value: true
 output:
   pagedown::html_resume:
     css: ['dd_cv.css', 'resume']
@@ -23,7 +25,8 @@ source("cv_printing_functions.r")
 # Read in all data and initialize a CV printer object
 CV <- create_CV_object(
   data_location = "{{{data_location}}}",  
-  pdf_mode = params$pdf_mode
+  pdf_mode = params$pdf_mode,
+  cache_data = params$cache_data
 )
 
 ```

--- a/inst/templates/render_cv.R
+++ b/inst/templates/render_cv.R
@@ -1,19 +1,30 @@
 # This script builds both the HTML and PDF versions of your CV
 
-# If you wanted to speed up rendering for googlesheets driven CVs you could use
-# this script to cache a version of the CV_Printer class with data already
-# loaded and load the cached version in the .Rmd instead of re-fetching it twice
-# for the HTML and PDF rendering. This exercise is left to the reader.
+# If you want to speed up rendering for googlesheets driven CVs you can cache a
+# version of your data This avoids having to fetch from google sheets twice and
+# will speed up rendering. It will also make things nicer if you have a
+# non-public sheet and want to take care of the authentication in an interactive
+# mode.
+# To use, simply uncomment the following lines and run them once.
+# If you need to update your data delete the "ddcv_cache.rds" file and re-run
+
+# source("CV_printing_functions.R")
+# create_CV_object(
+#   data_location = "{{{data_location}}}",
+#   cache_data = TRUE
+# )
+
+cache_data <- TRUE
 
 # Knit the HTML version
 rmarkdown::render("cv.rmd",
-                  params = list(pdf_mode = FALSE),
+                  params = list(pdf_mode = FALSE, cache_data = cache_data),
                   output_file = "cv.html")
 
 # Knit the PDF version to temporary html location
 tmp_html_cv_loc <- fs::file_temp(ext = ".html")
 rmarkdown::render("cv.rmd",
-                  params = list(pdf_mode = TRUE),
+                  params = list(pdf_mode = TRUE, cache_data = cache_data),
                   output_file = tmp_html_cv_loc)
 
 # Convert to PDF using Pagedown

--- a/man/use_datadriven_cv.Rd
+++ b/man/use_datadriven_cv.Rd
@@ -10,7 +10,7 @@ use_datadriven_cv(
   pdf_location = "https://github.com/nstrayer/cv/raw/master/strayer_cv.pdf",
   html_location = "nickstrayer.me/datadrivencv/",
   source_location = "https://github.com/nstrayer/datadrivencv",
-  which_files = "all",
+  which_files,
   output_dir = getwd(),
   create_output_dir = FALSE,
   use_network_logo = TRUE,

--- a/man/use_ddcv_template.Rd
+++ b/man/use_ddcv_template.Rd
@@ -7,7 +7,7 @@
 use_ddcv_template(
   file_name,
   params = NULL,
-  output_file_name = file_name,
+  output_file_name,
   output_dir = getwd(),
   create_output_dir = FALSE,
   warn_about_no_change = TRUE,


### PR DESCRIPTION
The previous regular expressions for links would not allow square or round brackets to exist alone as it assumed they were always part of markdown links. Now the regex is smarter about these and allows square or round bracketed text to occur and not get stripped away in an attempt to make a link substitution. 

Based on #29 