### PR TITLE
Fix updated dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,14 +14,14 @@ Imports:
     tidyr,
     glue,
     readr,
-    googlesheets4,
+    googlesheets4 (>= 1.0.0),
     lubridate,
     purrr,
     stringr,
     magrittr,
     pagedown,
     fs,
-    icon (>= 0.1.0),
+    icons (>= 0.1.0),
     whisker
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
@@ -31,4 +31,4 @@ Suggests:
     testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Remotes: 
-    ropenscilabs/icon
+    mitchelloharawild/icons

--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -29,7 +29,7 @@ create_CV_object <-  function(data_location,
     if(sheet_is_publicly_readable){
       # This tells google sheets to not try and authenticate. Note that this will only
       # work if your sheet has sharing set to "anyone with link can view"
-      googlesheets4::sheets_deauth()
+      googlesheets4::gs4_deauth()
     } else {
       # My info is in a public sheet so there's no need to do authentication but if you want
       # to use a private sheet, then this is the way you need to do it.

--- a/inst/templates/cv.Rmd
+++ b/inst/templates/cv.Rmd
@@ -60,7 +60,7 @@ datadrivencv::build_network_logo(CV$entries_data)
 
 ```{r}
 if(params$pdf_mode){
-  cat("View this CV online with links at _{{{html_location}}}_")
+  cat("View this CV online with links at *{{{html_location}}}*")
 } else {
   cat("[<i class='fas fa-download'></i> Download a PDF of this CV]({{pdf_location}})")
 }

--- a/tests/CV_printing_functions.R
+++ b/tests/CV_printing_functions.R
@@ -29,7 +29,7 @@ create_CV_object <-  function(data_location,
     if(sheet_is_publicly_readable){
       # This tells google sheets to not try and authenticate. Note that this will only
       # work if your sheet has sharing set to "anyone with link can view"
-      googlesheets4::sheets_deauth()
+      googlesheets4::gs4_deauth()
     } else {
       # My info is in a public sheet so there's no need to do authentication but if you want
       # to use a private sheet, then this is the way you need to do it.


### PR DESCRIPTION
Hi @nstrayer!

I'm using your template and `datadrivencv` package to built a CV on my own. On using the package I stumbled on some problems arising from updated dependencies. Namely:

* `icons` package: The icon package got renamed to `icons`. See [here](https://github.com/mitchelloharawild/icons#a-note-on-the-old-api) for details.
* `googlesheets4`: The deprecated `sheets_*()` functions were removed per 1.0.0 release (see [here](https://googlesheets4.tidyverse.org/news/index.html#other-changes-1-0-0)). I updated that.

Apart from above, the italic formatting using `_` did not work for me. I replaced that with `*` which should work in any case.

Let me know what you think!