### PR TITLE
Drop case-sensitive transformation and resolve dependency issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,5 +31,4 @@ Suggests:
     testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Remotes: 
-    ropenscilabs/icon
     mitchelloharawild/icons

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datadrivencv
 Type: Package
 Title: Templates and helper functions for building a CV with spreadsheets
-Version: 0.1.0
+Version: 0.1.1
 URL: http://nickstrayer.me/datadrivencv, https://github.com/nstrayer/datadrivencv
 Author: Nick Strayer
 Maintainer: Nick Strayer <nick.strayer@gmail.com>
@@ -14,16 +14,16 @@ Imports:
     tidyr,
     glue,
     readr,
-    googlesheets4,
+    googlesheets4 (>= 1.0.0),
     lubridate,
     purrr,
     stringr,
     magrittr,
     pagedown,
     fs,
-    icon (>= 0.1.0),
+    icons (>= 0.1.0),
     whisker
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Suggests: 
     knitr,
@@ -32,3 +32,4 @@ Suggests:
 VignetteBuilder: knitr
 Remotes: 
     ropenscilabs/icon
+    mitchelloharawild/icons

--- a/R/use_datadriven_cv.R
+++ b/R/use_datadriven_cv.R
@@ -17,7 +17,7 @@
 #' @param source_location Where is the code to build your CV hosted?
 #' @param open_files Should the added files be opened after creation?
 #' @param which_files What files should be placed? Takes a vector of possible
-#'   values `c("cv.rmd", "dd_cv.css", "render_cv.r", "cv_printing_functions.r")`
+#'   values `c("cv.Rmd", "dd_cv.css", "render_cv.R", "CV_printing_functions.R")`
 #'   or `"all"` for everything. This can be used to incrementally update the
 #'   printing functions or CSS without loosing customizations you've made to
 #'   other files.
@@ -28,7 +28,7 @@
 #'   package.
 #' @inheritParams use_ddcv_template
 #'
-#' @return `cv.rmd`, `dd_cv.css`, `render_cv.r`, and `cv_printing_functions.r`
+#' @return `cv.Rmd`, `dd_cv.css`, `render_cv.R`, and `CV_printing_functions.R`
 #'   written to the current working directory.
 #'
 #' @examples
@@ -63,15 +63,13 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
                               open_files = TRUE){
 
   if(is.character(which_files) && which_files == "all"){
-    which_files <- c("cv.rmd", "dd_cv.css", "render_cv.r", "cv_printing_functions.r")
+    which_files <- c("cv.Rmd", "dd_cv.css", "render_cv.R", "CV_printing_functions.R")
   }
-  # Make case-insensitive
-  which_files <- tolower(which_files)
 
-  if("cv.rmd" %in% which_files){
+  if("cv.Rmd" %in% which_files){
     # Sets the main Rmd template
     use_ddcv_template(
-      file_name = "cv.rmd",
+      file_name = "cv.Rmd",
       params = list(
         full_name = full_name,
         data_location = data_location,
@@ -95,18 +93,18 @@ use_datadriven_cv <- function(full_name = "Sarah Arcos",
     )
   }
 
-  if("render_cv.r" %in% which_files){
+  if("render_cv.R" %in% which_files){
     use_ddcv_template(
-      file_name = "render_cv.r",
+      file_name = "render_cv.R",
       output_dir = output_dir,
       create_output_dir,
       open_after_making = open_files
     )
   }
 
-  if("cv_printing_functions.r" %in% which_files){
+  if("CV_printing_functions.R" %in% which_files){
     use_ddcv_template(
-      file_name = "cv_printing_functions.r",
+      file_name = "CV_printing_functions.R",
       output_dir = output_dir,
       create_output_dir
     )

--- a/R/use_ddcv_template.R
+++ b/R/use_ddcv_template.R
@@ -1,6 +1,6 @@
 #' Use template file from package
 #'
-#' @param file_name Name of file from templates to use: e.g. `cv.rmd`.
+#' @param file_name Name of file from templates to use: e.g. `cv.Rmd`.
 #' @param params Parameters used to fill in `whisker` template
 #' @param output_file_name Name of file after being placed.
 #' @param output_dir Directory location for output to be placed in.

--- a/README.Rmd
+++ b/README.Rmd
@@ -91,7 +91,7 @@ This code is all that's needed to setup a full CV. It outputs five files:
 |`cv.Rmd`    | An RMarkdown file with various sections filled in. Edit this to fit your personal needs. |
 |`dd_cv.css` | A custom set of CSS styles that build on the default `Pagedown` "resume" template. Again, edit these as desired.|
 | `render_cv.R` | Use this script to build your CV in both PDF and HTML at the same time. |
-| `CV_printing_functions.r` | A series of functions that perform the dirty work of turning your spreadsheet data into markdown/html and making that output work for PDF printing. E.g. Replacing markdown links with superscripts and a links section, tweaking the CSS to account for chrome printing quirks, etc.. |
+| `CV_printing_functions.R` | A series of functions that perform the dirty work of turning your spreadsheet data into markdown/html and making that output work for PDF printing. E.g. Replacing markdown links with superscripts and a links section, tweaking the CSS to account for chrome printing quirks, etc.. |
 
 # Storing your data in spreadsheets
 
@@ -154,19 +154,19 @@ The function `use_csv_data_storage()` will set these up for you.
 
 # Rendering your CV
 
-Now that you have the templates setup and you've configured your data, the last thing to do is render. The easiest way to do this is by opening `cv.rmd` in RStudio and clicking the "Knit" button. This will render an HTML version of your CV. However, you most likely want a PDF version of your CV to go along with an HTML version. The easiest way to do this is to run the included script `render_cv.r`:
+Now that you have the templates setup and you've configured your data, the last thing to do is render. The easiest way to do this is by opening `cv.rmd` in RStudio and clicking the "Knit" button. This will render an HTML version of your CV. However, you most likely want a PDF version of your CV to go along with an HTML version. The easiest way to do this is to run the included script `render_cv.R`:
 
-### `render_cv.r`
+### `render_cv.R`
 
 ```{r, eval = FALSE, echo = TRUE}
 # Knit the HTML version
-rmarkdown::render("cv.rmd",
+rmarkdown::render("cv.Rmd",
                   params = list(pdf_mode = FALSE),
                   output_file = "cv.html")
 
 # Knit the PDF version to temporary html location
 tmp_html_cv_loc <- fs::file_temp(ext = ".html")
-rmarkdown::render("cv.rmd",
+rmarkdown::render("cv.Rmd",
                   params = list(pdf_mode = TRUE),
                   output_file = tmp_html_cv_loc)
 
@@ -182,7 +182,7 @@ embed_png("html_vs_pdf_output.png")
 
 
 
-This script will render your CV in HTML and output it as `cv.html`, it will also turn on the `pdf_mode` parameter in `cv.rmd`, which will strip the links out and place them at the end linked by inline superscripts. Once the pdf version is rendered to HTML, it will then turn that HTML into a PDF using `pagedown::chrome_print()`. By using this script you can easily make sure your get both versions rendered at the same time without having to manually go in and toggle the pdf mode parameter in the yaml header and then use the print dialog in your browser. 
+This script will render your CV in HTML and output it as `cv.html`, it will also turn on the `pdf_mode` parameter in `cv.Rmd`, which will strip the links out and place them at the end linked by inline superscripts. Once the pdf version is rendered to HTML, it will then turn that HTML into a PDF using `pagedown::chrome_print()`. By using this script you can easily make sure your get both versions rendered at the same time without having to manually go in and toggle the pdf mode parameter in the yaml header and then use the print dialog in your browser. 
 
 # Questions?
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -88,10 +88,10 @@ This code is all that's needed to setup a full CV. It outputs five files:
 
 |  File    |  Description |
 | ----     | ----         |
-|`cv.rmd`    | An RMarkdown file with various sections filled in. Edit this to fit your personal needs. |
+|`cv.Rmd`    | An RMarkdown file with various sections filled in. Edit this to fit your personal needs. |
 |`dd_cv.css` | A custom set of CSS styles that build on the default `Pagedown` "resume" template. Again, edit these as desired.|
-| `render_cv.r` | Use this script to build your CV in both PDF and HTML at the same time. |
-| `cv_printing_functions.r` | A series of functions that perform the dirty work of turning your spreadsheet data into markdown/html and making that output work for PDF printing. E.g. Replacing markdown links with superscripts and a links section, tweaking the CSS to account for chrome printing quirks, etc.. |
+| `render_cv.R` | Use this script to build your CV in both PDF and HTML at the same time. |
+| `CV_printing_functions.r` | A series of functions that perform the dirty work of turning your spreadsheet data into markdown/html and making that output work for PDF printing. E.g. Replacing markdown links with superscripts and a links section, tweaking the CSS to account for chrome printing quirks, etc.. |
 
 # Storing your data in spreadsheets
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 # datadrivencv <img src="man/figures/logo.svg" width="185px" align="right" style="border:1px solid black;">
 
 <!-- badges: start -->
-
 <!-- badges: end -->
 
 The goal of datadrivencv is to ease the burden of maintaining a CV by
@@ -51,7 +50,7 @@ so if you want to change it you can do so.
 The package aims to bootstrap you to a working data-driven CV pipeline.
 Serving as a jumping off point for you to build your own custom CV, you
 may at first want to leave it as is and then slowly tweak things to keep
-it fresh. You have all the code, so you can\!
+it fresh. You have all the code, so you can!
 
 # Using it
 
@@ -73,7 +72,7 @@ datadrivencv::use_datadriven_cv(
 The available arguments are:
 
 | Argument           | Description                                                                                                                                                                                                           |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `full_name`        | Your full name, used in title of document and header                                                                                                                                                                  |
 | `data_location`    | Path of the spreadsheets holding all your data. This can be either a URL to a google sheet with multiple sheets containing the four data types or a path to a folder containing four `.csv`s with the neccesary data. |
 | `pdf_location`     | What location will the PDF of this CV be hosted at?                                                                                                                                                                   |
@@ -86,11 +85,11 @@ This code is all that’s needed to setup a full CV. It outputs five
 files:
 
 | File                      | Description                                                                                                                                                                                                                                                                            |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cv.rmd`                  | An RMarkdown file with various sections filled in. Edit this to fit your personal needs.                                                                                                                                                                                               |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cv.Rmd`                  | An RMarkdown file with various sections filled in. Edit this to fit your personal needs.                                                                                                                                                                                               |
 | `dd_cv.css`               | A custom set of CSS styles that build on the default `Pagedown` “resume” template. Again, edit these as desired.                                                                                                                                                                       |
-| `render_cv.r`             | Use this script to build your CV in both PDF and HTML at the same time.                                                                                                                                                                                                                |
-| `cv_printing_functions.r` | A series of functions that perform the dirty work of turning your spreadsheet data into markdown/html and making that output work for PDF printing. E.g. Replacing markdown links with superscripts and a links section, tweaking the CSS to account for chrome printing quirks, etc.. |
+| `render_cv.R`             | Use this script to build your CV in both PDF and HTML at the same time.                                                                                                                                                                                                                |
+| `CV_printing_functions.R` | A series of functions that perform the dirty work of turning your spreadsheet data into markdown/html and making that output work for PDF printing. E.g. Replacing markdown links with superscripts and a links section, tweaking the CSS to account for chrome printing quirks, etc.. |
 
 # Storing your data in spreadsheets
 
@@ -122,7 +121,7 @@ The four spreadsheets that are needed and their columns are:
 ### `entries`
 
 | Column          | Description                                                                                                                                                             |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `section`       | Where in your CV this entry belongs                                                                                                                                     |
 | `title`         | Main title of the entry                                                                                                                                                 |
 | `loc`           | Location the entry occured                                                                                                                                              |
@@ -134,21 +133,21 @@ The four spreadsheets that are needed and their columns are:
 ### `language_skills`
 
 | Column  | Description                     |
-| ------- | ------------------------------- |
+|---------|---------------------------------|
 | `skill` | Name of language                |
 | `level` | Relative numeric level of skill |
 
 ### `text_blocks`
 
 | Column | Description                                           |
-| ------ | ----------------------------------------------------- |
+|--------|-------------------------------------------------------|
 | `loc`  | Id used for finding text block                        |
 | `text` | Contents of text block. Supports markdown formatting. |
 
 ### `contact info`
 
 | Column    | Description                                                 |
-| --------- | ----------------------------------------------------------- |
+|-----------|-------------------------------------------------------------|
 | `loc`     | Id of contact section                                       |
 | `icon`    | Icon used from font-awesome 4 to label this contact section |
 | `contact` | The actual value written for the contact entry              |
@@ -156,10 +155,11 @@ The four spreadsheets that are needed and their columns are:
 ## Using `.csv`s instead of google sheets
 
 Don’t want to use google sheets to store your data? Not a problem. Just
-make four `.csvs` (`entries.csv, language_skills.csv, text_blocks.csv,
-contact_info.csv`) that have the same matching format as above and pass
-the folder containing those as your `data_location` when initializing
-with `use_datadriven_cv()`.
+make four `.csvs`
+(`entries.csv, language_skills.csv, text_blocks.csv, contact_info.csv`)
+that have the same matching format as above and pass the folder
+containing those as your `data_location` when initializing with
+`use_datadriven_cv()`.
 
 The function `use_csv_data_storage()` will set these up for you.
 
@@ -170,19 +170,19 @@ the last thing to do is render. The easiest way to do this is by opening
 `cv.rmd` in RStudio and clicking the “Knit” button. This will render an
 HTML version of your CV. However, you most likely want a PDF version of
 your CV to go along with an HTML version. The easiest way to do this is
-to run the included script `render_cv.r`:
+to run the included script `render_cv.R`:
 
-### `render_cv.r`
+### `render_cv.R`
 
 ``` r
 # Knit the HTML version
-rmarkdown::render("cv.rmd",
+rmarkdown::render("cv.Rmd",
                   params = list(pdf_mode = FALSE),
                   output_file = "cv.html")
 
 # Knit the PDF version to temporary html location
 tmp_html_cv_loc <- fs::file_temp(ext = ".html")
-rmarkdown::render("cv.rmd",
+rmarkdown::render("cv.Rmd",
                   params = list(pdf_mode = TRUE),
                   output_file = tmp_html_cv_loc)
 
@@ -198,7 +198,7 @@ pagedown::chrome_print(input = tmp_html_cv_loc,
 </div>
 
 This script will render your CV in HTML and output it as `cv.html`, it
-will also turn on the `pdf_mode` parameter in `cv.rmd`, which will strip
+will also turn on the `pdf_mode` parameter in `cv.Rmd`, which will strip
 the links out and place them at the end linked by inline superscripts.
 Once the pdf version is rendered to HTML, it will then turn that HTML
 into a PDF using `pagedown::chrome_print()`. By using this script you
@@ -214,17 +214,10 @@ me know. Not comfortable with github issues? Tweet the question at me on
 Twitter: [@nicholasstrayer](https://twitter.com/NicholasStrayer).
 
 <!-- Twitter Card data -->
-
 <meta name="twitter:card" content="summary">
-
 <meta name="twitter:site" content="@nicholasstrayer">
-
 <meta name="twitter:title" content="datadrivencv">
-
 <meta name="twitter:description" content="n R package for building your CV with data">
-
 <meta name="twitter:creator" content="@nicholasstrayer">
-
 <!-- Twitter Summary card images must be at least 120x120px -->
-
 <meta name="twitter:image" content="https://github.com/nstrayer/datadrivencv/blob/master/man/figures/logo.svg">

--- a/inst/templates/CV_printing_functions.R
+++ b/inst/templates/CV_printing_functions.R
@@ -29,7 +29,7 @@ create_CV_object <-  function(data_location,
     if(sheet_is_publicly_readable){
       # This tells google sheets to not try and authenticate. Note that this will only
       # work if your sheet has sharing set to "anyone with link can view"
-      googlesheets4::sheets_deauth()
+      googlesheets4::gs4_deauth()
     } else {
       # My info is in a public sheet so there's no need to do authentication but if you want
       # to use a private sheet, then this is the way you need to do it.

--- a/inst/templates/cv.Rmd
+++ b/inst/templates/cv.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 )
 
 library(magrittr) # For the pipe
-source("cv_printing_functions.r")
+source("CV_printing_functions.R")
 
 # Read in all data and initialize a CV printer object
 CV <- create_CV_object(
@@ -60,7 +60,7 @@ datadrivencv::build_network_logo(CV$entries_data)
 
 ```{r}
 if(params$pdf_mode){
-  cat("View this CV online with links at _{{{html_location}}}_")
+  cat("View this CV online with links at *{{{html_location}}}*")
 } else {
   cat("[<i class='fas fa-download'></i> Download a PDF of this CV]({{pdf_location}})")
 }

--- a/inst/templates/render_cv.R
+++ b/inst/templates/render_cv.R
@@ -6,13 +6,13 @@
 # for the HTML and PDF rendering. This exercise is left to the reader.
 
 # Knit the HTML version
-rmarkdown::render("cv.rmd",
+rmarkdown::render("cv.Rmd",
                   params = list(pdf_mode = FALSE),
                   output_file = "cv.html")
 
 # Knit the PDF version to temporary html location
 tmp_html_cv_loc <- fs::file_temp(ext = ".html")
-rmarkdown::render("cv.rmd",
+rmarkdown::render("cv.Rmd",
                   params = list(pdf_mode = TRUE),
                   output_file = tmp_html_cv_loc)
 

--- a/man/use_datadriven_cv.Rd
+++ b/man/use_datadriven_cv.Rd
@@ -34,7 +34,7 @@ at?}
 \item{source_location}{Where is the code to build your CV hosted?}
 
 \item{which_files}{What files should be placed? Takes a vector of possible
-values \code{c("cv.rmd", "dd_cv.css", "render_cv.r", "cv_printing_functions.r")}
+values \code{c("cv.Rmd", "dd_cv.css", "render_cv.R", "CV_printing_functions.R")}
 or \code{"all"} for everything. This can be used to incrementally update the
 printing functions or CSS without loosing customizations you've made to
 other files.}
@@ -51,7 +51,7 @@ package.}
 \item{open_files}{Should the added files be opened after creation?}
 }
 \value{
-\code{cv.rmd}, \code{dd_cv.css}, \code{render_cv.r}, and \code{cv_printing_functions.r}
+\code{cv.Rmd}, \code{dd_cv.css}, \code{render_cv.R}, and \code{CV_printing_functions.R}
 written to the current working directory.
 }
 \description{

--- a/man/use_ddcv_template.Rd
+++ b/man/use_ddcv_template.Rd
@@ -15,7 +15,7 @@ use_ddcv_template(
 )
 }
 \arguments{
-\item{file_name}{Name of file from templates to use: e.g. \code{cv.rmd}.}
+\item{file_name}{Name of file from templates to use: e.g. \code{cv.Rmd}.}
 
 \item{params}{Parameters used to fill in \code{whisker} template}
 

--- a/tests/CV_printing_functions.R
+++ b/tests/CV_printing_functions.R
@@ -29,7 +29,7 @@ create_CV_object <-  function(data_location,
     if(sheet_is_publicly_readable){
       # This tells google sheets to not try and authenticate. Note that this will only
       # work if your sheet has sharing set to "anyone with link can view"
-      googlesheets4::sheets_deauth()
+      googlesheets4::gs4_deauth()
     } else {
       # My info is in a public sheet so there's no need to do authentication but if you want
       # to use a private sheet, then this is the way you need to do it.

--- a/tests/date_options/setup_test.R
+++ b/tests/date_options/setup_test.R
@@ -8,5 +8,5 @@ datadrivencv::use_datadriven_cv(
   output_dir = here("tests/date_options"),
   open_files = FALSE,
   which_files = "all"
-  # which_files = c("cv_printing_functions.r")
+  # which_files = c("cv_printing_functions.R")
 )

--- a/tests/testthat/test-rendering_cv.R
+++ b/tests/testthat/test-rendering_cv.R
@@ -21,7 +21,7 @@ test_that("Rendering to HTML works", {
   )
 
   # Knit the HTML version
-  html_knit_res <- rmarkdown::render(fs::path(temp_dir, "cv.rmd"),
+  html_knit_res <- rmarkdown::render(fs::path(temp_dir, "cv.Rmd"),
                                      params = list(pdf_mode = FALSE),
                                      output_file = fs::path(temp_dir, "cv.html"),
                                      quiet = TRUE)
@@ -29,7 +29,7 @@ test_that("Rendering to HTML works", {
   expect_true(fs::file_exists(html_knit_res))
 
   # Knit version for PDF
-  pdf_knit_res <-rmarkdown::render(fs::path(temp_dir, "cv.rmd"),
+  pdf_knit_res <-rmarkdown::render(fs::path(temp_dir, "cv.Rmd"),
                                    params = list(pdf_mode = TRUE),
                                    output_file = fs::path(temp_dir, "cv_4_pdf.html"),
                                    quiet = TRUE)

--- a/tests/testthat/test-use_datadriven_cv.R
+++ b/tests/testthat/test-use_datadriven_cv.R
@@ -10,7 +10,7 @@ test_that("Addition of all files works", {
     open_files = FALSE
   )
   expect_true(
-    all(c("cv.rmd", "dd_cv.css", "render_cv.r", "cv_printing_functions.r") %in% list.files(temp_dir))
+    all(c("cv.Rmd", "dd_cv.css", "render_cv.R", "CV_printing_functions.R") %in% list.files(temp_dir))
   )
 
   # Clean up temp dir
@@ -27,15 +27,15 @@ test_that("Addition of subset of files", {
     full_name = "Testing McTester",
     data_location = "here/be/my/data/",
     output_dir = temp_dir,
-    which_files = c("render_cv.r", "cv_printing_functions.r"),
+    which_files = c("render_cv.R", "CV_printing_functions.R"),
     open_files = FALSE
   )
 
   expect_true(
-    all(c("render_cv.r", "cv_printing_functions.r") %in% list.files(temp_dir))
+    all(c("render_cv.R", "CV_printing_functions.R") %in% list.files(temp_dir))
   )
 
-  expect_false("cv.rmd" %in% list.files(temp_dir))
+  expect_false("cv.Rmd" %in% list.files(temp_dir))
   expect_false("dd_cv.css" %in% list.files(temp_dir))
   # Clean up temp dir
   fs::dir_walk(temp_dir, fs::file_delete)
@@ -63,10 +63,10 @@ test_that("Warns when trying to update a file with no change", {
       full_name = "Testing McTester",
       data_location = "here/be/my/data/",
       output_dir = temp_dir,
-      which_files = c("cv.rmd"),
+      which_files = c("cv.Rmd"),
       open_files = FALSE
     ),
-    "cv.rmd already exists and there are no differences with the current version.",
+    "cv.Rmd already exists and there are no differences with the current version.",
     fixed = TRUE
   )
 
@@ -76,7 +76,7 @@ test_that("Warns when trying to update a file with no change", {
       full_name = "Testing McTester the second",
       data_location = "here/be/my/data/",
       output_dir = temp_dir,
-      which_files = c("cv.rmd"),
+      which_files = c("cv.Rmd"),
       open_files = FALSE
     )
   )


### PR DESCRIPTION
I wasn't able to run `use_datadriven_cv()` because files are case-sensitive on linux so the templates weren't being found.

This PR removes that transformation and keeps the .R/Rmd casing.

Additionally, resolves the dependency issue with icon and googlesheets4, so
closes #60 
closes #69 
closes #73 
closes #77 
incorporating all the changes in those. 

All tests pass on linux (x86_64-pc-linux-gnu R version 4.1.2 (2021-11-01)) but not tested on other platforms.

I'm also able to generate a CV with these changes. Thanks for this package!